### PR TITLE
Update Graph Visualization to use TMPro

### DIFF
--- a/EdgeStyle.cs
+++ b/EdgeStyle.cs
@@ -18,7 +18,7 @@ namespace GraphVisualization
         /// Color in which to draw the edge.
         /// </summary>
         [Tooltip("Color in which to render the edge")]
-        public Color Color = new Color(1,1,1);
+        public Color Color = new Color(1, 1, 1);
         /// <summary>
         /// Width of the line to draw, in pixels.
         /// </summary>
@@ -51,7 +51,7 @@ namespace GraphVisualization
         /// Font in which to draw label.
         /// </summary>
         [Tooltip("Font for label")]
-        public Font Font;
+        public TMPro.TMP_FontAsset Font;
         /// <summary>
         /// Point size in which to draw label.
         /// </summary>
@@ -66,7 +66,7 @@ namespace GraphVisualization
         /// The style in which to render the label.
         /// </summary>
         [Tooltip("FontStyle (e.g. italic) in which to render the label.")]
-        public FontStyle FontStyle = FontStyle.Normal;
+        public TMPro.FontStyles FontStyle = TMPro.FontStyles.Normal;
 
         /// <summary>
         /// Prefab to use for making edges
@@ -74,7 +74,7 @@ namespace GraphVisualization
         [Tooltip("Prefab to instantiate to make a new edge in this style, if different from the default in Graph.")]
         public GameObject Prefab;
 
-        
+
         /// <summary>
         /// Copy the style
         /// </summary>

--- a/GraphEdge.cs
+++ b/GraphEdge.cs
@@ -25,7 +25,6 @@
 
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEngine.UI;
 
 namespace GraphVisualization
 {
@@ -39,7 +38,7 @@ namespace GraphVisualization
         public GraphNode EndNode;
         public string Label;
         public EdgeStyle Style;
-        private Text text;
+        private TMPro.TextMeshProUGUI text;
         private RectTransform rectTransform;
 
         /// <summary>
@@ -51,14 +50,13 @@ namespace GraphVisualization
             this.EndNode = endNode;
             this.Label = label;
             this.Style = style;
-            text = GetComponent<Text>();
+            text = GetComponent<TMPro.TextMeshProUGUI>();
             if (text != null)
             {
                 text.text = label;
-                if (style.Font != null)
-                    text.font = style.Font;
-                if (style.FontSize != 0)
-                    text.fontSize = style.FontSize;
+                if (style.Font != null) { text.font = style.Font; }
+                if (style.FontSize != 0) { text.fontSize = style.FontSize; }
+
                 text.fontStyle = style.FontStyle;
             }
 
@@ -82,10 +80,7 @@ namespace GraphVisualization
             rectTransform.localEulerAngles = new Vector3(0, 0, angle);
         }
 
-        public void Update()
-        {
-            UpdatePosition();
-        }
+        public void Update() => UpdatePosition();
 
         /// <summary>
         /// Called to adjust color of edge label when selected node in the graph changes.
@@ -93,13 +88,9 @@ namespace GraphVisualization
         /// </summary>
         public void SelectionChanged(Graph g, GraphNode selectedNode)
         {
-            if (text != null)
-                text.color =
-                    (selectedNode == null || StartNode == selectedNode || selectedNode
-                        ? 1
-                        : g.GreyOutFactor)
-                    * Style.Color
-                    ;
+            if (text == null) { return; }
+            bool greyout = selectedNode == null || StartNode == selectedNode || selectedNode;
+            text.color = Style.Color * (greyout ? 1 : g.GreyOutFactor);
         }
     }
 }

--- a/GraphEdge.cs
+++ b/GraphEdge.cs
@@ -50,7 +50,7 @@ namespace GraphVisualization
             this.EndNode = endNode;
             this.Label = label;
             this.Style = style;
-            text = GetComponent<TMPro.TextMeshProUGUI>();
+            text = GetComponentInChildren<TMPro.TextMeshProUGUI>();
             if (text != null)
             {
                 text.text = label;

--- a/GraphNode.cs
+++ b/GraphNode.cs
@@ -43,7 +43,7 @@ namespace GraphVisualization
         public NodeStyle Style;
         private RectTransform rectTransform;
         private Graph graph;
-        private Text labelMesh;
+        private TMPro.TextMeshProUGUI labelMesh;
 
         /// <summary>
         /// The current position as computed by the spring physics system in Graph.cs
@@ -72,7 +72,7 @@ namespace GraphVisualization
             Key = key;
             Label = label;
             Style = style;
-            labelMesh = GetComponent<Text>();
+            labelMesh = GetComponent<TMPro.TextMeshProUGUI>();
             if (labelMesh != null)
             {
                 labelMesh.text = label;

--- a/GraphNode.cs
+++ b/GraphNode.cs
@@ -72,7 +72,7 @@ namespace GraphVisualization
             Key = key;
             Label = label;
             Style = style;
-            labelMesh = GetComponent<TMPro.TextMeshProUGUI>();
+            labelMesh = GetComponentInChildren<TMPro.TextMeshProUGUI>();
             if (labelMesh != null)
             {
                 labelMesh.text = label;

--- a/NodeStyle.cs
+++ b/NodeStyle.cs
@@ -23,7 +23,7 @@ namespace GraphVisualization
         /// Font in which to draw label.
         /// </summary>
         [Tooltip("Font in which to render the node")]
-        public Font Font;
+        public TMPro.TMP_FontAsset Font;
         /// <summary>
         /// Point size in which to draw label.
         /// </summary>
@@ -33,7 +33,7 @@ namespace GraphVisualization
         /// The style in which to render the node's label.
         /// </summary>
         [Tooltip("Font style (e.g. italic) in which to render the node label.")]
-        public FontStyle FontStyle = FontStyle.Normal;
+        public TMPro.FontStyles FontStyle = TMPro.FontStyles.Normal;
 
         /// <summary>
         /// Prefab to use for making nodes


### PR DESCRIPTION
__NOTE! This requires an update to the prefabs in the o.g. ianhorswill/imaginarium repository. There is an open PR there, and unfortunately there isn't a graceful way to tie these two PRs together.__

Change the text fields in GraphEdge and GraphNode to TMPro

- In particular, switch the fields which pertained to text (`Text`, `FontStyles`) to their TMPro analogs. 
- Additionally, make the calls to `GetComponent<TMPro.TMProUGUI>` into corresponding `GetComponentInChildren`, since putting the text items into children gameobjects makes relative positioning easier for future folks who work on this content.